### PR TITLE
#263 無限スクロールのアイコンをMatelial design liteのものに変更する

### DIFF
--- a/js/infinite-scroll.js
+++ b/js/infinite-scroll.js
@@ -26,6 +26,10 @@ $(function(){
     ias.extension(new IASNoneLeftExtension({
       html: '<div class="ias_noneleft">最後の記事です</div>', // optionally
     }));
+    ias.on('noneLeft', function() {
+      console.log('last page');
+      $('.ias-spinner').hide();
+    });
     // ias.extension(new IASPagingExtension());
     // ias.extension(new IASHistoryExtension({
     //     prev: '.qa-page-prev',

--- a/js/infinite-scroll.js
+++ b/js/infinite-scroll.js
@@ -1,13 +1,23 @@
 $(function(){
-	if($(".qa-q-list").length && $(".qa-page-links-list").length) {
-		var ias = $('.mdl-layout__content').ias({
-			container: ".qa-q-list"
-			,item: ".qa-q-list-item"
-			,pagination: ".qa-page-links-list"
-			,next: ".qa-page-next"
-			,delay: 600
-		});
-    ias.extension(new IASSpinnerExtension());
+  if($(".qa-q-list").length && $(".qa-page-links-list").length) {
+    if (material_lite) {
+      var ias = $(".mdl-layout__content").ias({
+        container: ".qa-q-list"
+        ,item: ".qa-q-list-item"
+        ,pagination: ".qa-page-links-list"
+        ,next: ".qa-page-next"
+        ,delay: 600
+      });
+    } else {      
+        var ias = $.ias({
+          container: ".qa-q-list"
+          ,item: ".qa-q-list-item"
+          ,pagination: ".qa-page-links-list"
+          ,next: ".qa-page-next"
+          ,delay: 600
+        });
+        ias.extension(new IASSpinnerExtension());
+    }
     ias.extension(new IASTriggerExtension({
         text: "続きを読む",
         textPrev: "前を読む",
@@ -20,5 +30,5 @@ $(function(){
     // ias.extension(new IASHistoryExtension({
     //     prev: '.qa-page-prev',
     // }));
-	}
+  }
 });

--- a/qa-infinite-scroll-layer.php
+++ b/qa-infinite-scroll-layer.php
@@ -20,6 +20,11 @@ class qa_html_theme_layer extends qa_html_theme_base
     {
         qa_html_theme_base::head_script();
         if ($this->template === 'questions') {
+            if (strpos(qa_opt('site_theme'), 'q2a-material-lite') !== false) {
+                $this->output('<script>var material_lite = true;</script>');
+            } else {
+                $this->output('<script>var material_lite = false;</script>');
+            }
             $this->output('<SCRIPT TYPE="text/javascript" SRC="'.$this->infscr->pluginjsurl.'jquery-ias.min.js"></SCRIPT>');
             $this->output('<SCRIPT TYPE="text/javascript" SRC="'.$this->infscr->pluginjsurl.'infinite-scroll.js"></SCRIPT>');
         }
@@ -30,6 +35,16 @@ class qa_html_theme_layer extends qa_html_theme_base
         qa_html_theme_base::head_css();
         if ($this->template === 'questions') {
             $this->output('<LINK REL="stylesheet" TYPE="text/css" HREF="'.$this->infscr->plugincssurl.'jquery.ias.css"/>');
+        }
+    }
+    
+    function q_list_items($q_items)
+    {
+        qa_html_theme_base::q_list_items($q_items);
+        if ($this->template === 'questions' &&
+            strpos(qa_opt('site_theme'), 'q2a-material-lite') !== false) {
+            
+            $this->output('<div class="ias-spinner" style="align:center;"><span class="mdl-spinner mdl-js-spinner is-active" style="height:20px;width:20px;"></span></div>');
         }
     }
 }


### PR DESCRIPTION
- Infinite Ajax Scroll の spinner エクステンションを使用したかったが、HTMLタグでのローディングアイコンに対応していなかったので別の方法で対応
- テーマが q2a-material-lite の場合
  - 質問一覧の一番最後に ローディングアイコンタグを挿入
  - 新しいページが読み込まれると アイコンタグはページの一番下になるので、画面から消える
  - 最後のページの場合はローディングアイコンを消す
- その他のテーマの場合はInfinite Ajax Scroll の spinner エクステンション を使用する
